### PR TITLE
fix: 🐛 output format set to 'stylish'

### DIFF
--- a/ci.js
+++ b/ci.js
@@ -8,6 +8,9 @@ module.exports = {
     'node': true,
   },
 
+  // Define the cli output format
+  'format': 'stylish',
+
   // Define a TS enabled parser
   // NOTE: Even though we aren't enforcing any TypeScript rules here, this is still needed so that ESLint can understand `.ts` files
   'parser': '@typescript-eslint/parser',


### PR DESCRIPTION
Closes: #16

Once this is released we can remove the `--format stylish` flag from all our eslint commands.