### PR TITLE
Update migration notes, update rules and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ $ yarn add eslint \
   @angular-eslint/eslint-plugin-template \
   @angular-eslint/template-parser \
   @typescript-eslint/eslint-plugin \
-  @typescript-eslint/parser -D
+  @typescript-eslint/parser \
+  eslint-import-resolver-typescript \
+  eslint-plugin-deprecation \
+  eslint-plugin-import \
+  eslint-plugin-jsdoc \
+  eslint-plugin-prefer-arrow \
+  -D
 ```
 
 
@@ -68,8 +74,8 @@ module.exports = {
 };
 ```
 
-NOTE: If your primary TSConfig file is at the project root and named `tsconfig.json` *you need to overwrite the parser
-options to point to your config file*.
+NOTE: If your primary TSConfig file is *NOT* at the project root and named `tsconfig.json` *you need to overwrite the
+parser options to point to your config file*.
 
 ```javascript
 module.exports = {
@@ -123,7 +129,7 @@ Rules can be adjusted for specific globs at the consumer level using [ESLint fil
 
 ```javascript
 module.exports = {
-  "extends": ['@terminus/eslint-config-frontend/development'],
+  "extends": ['@terminus/eslint-config-frontend'],
   "overrides": [
     // Disable certain rules for spec and mock files:
     {

--- a/rules.js
+++ b/rules.js
@@ -336,7 +336,7 @@ module.exports = {
       SEVERITY,
       {
         // A fallthrough is only allowed when a comment is added explicitly calling out the unique behavior.
-        'commentPattern': 'break[\\s\\w]*omitted',
+        'commentPattern': '[fF]alls?.[tT]hrough|[bB]reak|intentional',
       },
     ],
 

--- a/rules.js
+++ b/rules.js
@@ -222,7 +222,6 @@ module.exports = {
     ],
     'jsdoc/newline-after-description': SEVERITY,
     'jsdoc/require-hyphen-before-param-description': SEVERITY,
-    'jsdoc/require-jsdoc': SEVERITY,
     'jsdoc/require-param': SEVERITY,
     'jsdoc/no-types': SEVERITY,
     'jsdoc/valid-types': SEVERITY,


### PR DESCRIPTION
- allow more comments to bypass no-fallthrough
- correct installation docs
- add migration instructions
- no longer require JSDoc comments at the base level